### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,8 @@
 
 AC_PREREQ(2.61)
 AC_INIT([Newick Utils],[1.6],[thomas.junier@.unige.ch])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
+LT_INIT
 
 AC_CONFIG_SRCDIR([src/display.c])
 


### PR DESCRIPTION
When running autoreconf (GNU Autoconf) 2.69, I have to make these changes to get it to run.

I still get the following warnings, and the tests don't run right, but the binaries appear healthy.

```
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: Consider adding `AC_CONFIG_MACRO_DIR([m4])' to configure.ac and
libtoolize: rerunning libtoolize, to keep the correct libtool macros in-tree.
libtoolize: Consider adding `-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
configure.ac:7: installing './config.guess'
configure.ac:7: installing './config.sub'
Makefile.am:32: warning: shell uname -s: non-POSIX variable name
Makefile.am:32: (probably a GNU make extension)
Makefile.am:32: warning: shell uname -m: non-POSIX variable name
Makefile.am:32: (probably a GNU make extension)
```

Thank you for the awesome code!