### PR TITLE
Fixes compilation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ tags
 test-driver
 ylwrap
 compile
+CMakeFiles
+CMakeCache.txt
+*.cmake
+*.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(nutils
 	set.c
 	to_newick.c
 	concat.c
+	readline.c
 	)
 
 # simple cases 

--- a/src/address_parser_status.h
+++ b/src/address_parser_status.h
@@ -13,4 +13,4 @@ enum address_parser_status_type {
  * returns either \c NULL or the top-level enode of the address, so we need to
  * use an extern variable to convey its status. */
 
-enum address_parser_status_type address_parser_status;
+extern enum address_parser_status_type address_parser_status;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -22,6 +22,7 @@ test_order_tree
 test_readline
 test_rnode
 test_rnode_iterator
+test_set
 test_subtree
 test_svg_graph_radial
 test_to_newick


### PR DESCRIPTION
With these fixes I got newick_utils to compile successfully on Ubuntu 20.  